### PR TITLE
Improve mesh splitting

### DIFF
--- a/oai_analysis/mesh_processing.py
+++ b/oai_analysis/mesh_processing.py
@@ -21,6 +21,7 @@ import trimesh
 import vtk
 from vtk.util import numpy_support as ns
 from sklearn.decomposition import PCA
+from sklearn.preprocessing import normalize
 
 # Helper Functions for Mesh Processing
 
@@ -274,7 +275,7 @@ def split_femoral_cartilage_surface(mesh, face_normal, face_centroid, num_divisi
     center = (bbox_min + bbox_max) / 2
 
     inner_outer_label_list = np.zeros(mesh.GetNumberOfCells())  # up:1, down:-1
-    connect_direction = center - face_centroid
+    connect_direction = normalize(center - face_centroid, axis=1, norm='l2')
 
     dot_output = np.multiply(connect_direction, face_normal)
     y_coord = mesh_centroids_normalized[:, 1]

--- a/oai_analysis/mesh_processing.py
+++ b/oai_analysis/mesh_processing.py
@@ -232,8 +232,8 @@ def split_tibial_cartilage_surface(mesh, mesh_normals, mesh_centroids):
     # transfer 0/1 labels to -1/1 labels
     inner_outer_label_list = labels * 2 - 1
 
-    # set inner surface which contains mostly positive normals
-    if mesh_normals[inner_outer_label_list == -1, 1].mean() < 0:
+    # set inner surface which contains mostly negative normals
+    if mesh_normals[inner_outer_label_list == -1, 2].mean() > 0:
         inner_outer_label_list = -inner_outer_label_list
 
     inner_face_list = np.where(inner_outer_label_list == -1)[0]


### PR DESCRIPTION
Hey @dzenanz , a few updates here on the mesh splitting method.
- Keep the largest island(s): I used the vtk polydata filter to keep only the connect largest components from the segmentation. Feel free to swap it with imaged based filter if you feel it could make it faster. One thing to note is that there may be issues when the TC segmentation creates more islands than expected. The example I used showed a weak connection on one of the TCs.
- Fix TC labels: I believe the outer TC should be facing the FC direction
- Normalize connection_direction to improve splitting: Keeping the largest island didn't really resolve the issue. I experimented with removing the scale component of connection_direction and found it work well.

Please give it a try and let me know what you think, thanks.

![image](https://github.com/user-attachments/assets/a560bb61-fd38-4fd8-a21e-e3eb54983033)
![image](https://github.com/user-attachments/assets/6b9fbb3d-020f-48c0-80dd-e87997ce823b)

